### PR TITLE
add repositories for community-extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,20 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>camunda-bpm-community-extensions</id>
+            <name>camunda BPM Snapshot Maven Repository</name>
+            <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+            <id>camunda-bpm-community-extensions-snapshots</id>
+            <name>camunda BPM Snapshot Maven Repository</name>
+            <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
     </repositories>
     -->
 


### PR DESCRIPTION
If your extension depends on another extensions, its convenient to have the repos already defined in the pom.xml.